### PR TITLE
cron.*: Use path from PREFIX for zfs-auto-snapshot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ install:
 	install etc/zfs-auto-snapshot.cron.daily    $(DESTDIR)/etc/cron.daily/zfs-auto-snapshot
 	install etc/zfs-auto-snapshot.cron.weekly   $(DESTDIR)/etc/cron.weekly/zfs-auto-snapshot
 	install etc/zfs-auto-snapshot.cron.monthly  $(DESTDIR)/etc/cron.monthly/zfs-auto-snapshot
+	sed -i -e "s:zfs-auto-snapshot:$(DESTDIR)$(PREFIX)/sbin/zfs-auto-snapshot:g" $(DESTDIR)/etc/cron.{d,hourly,daily,weekly,monthly}/zfs-auto-snapshot
 	install -d $(DESTDIR)$(PREFIX)/share/man/man8
 	install src/zfs-auto-snapshot.8 $(DESTDIR)$(PREFIX)/share/man/man8/zfs-auto-snapshot.8
 	install -d $(DESTDIR)$(PREFIX)/sbin


### PR DESCRIPTION
Change "zfs-auto-snapshot" to the absolute path when installing

Inspired by #44

Issue #47